### PR TITLE
fix(timeouts): [ENG-749] Making timeouts configurable

### DIFF
--- a/mempool/config.go
+++ b/mempool/config.go
@@ -49,6 +49,8 @@ type (
 		txDecoder sdk.TxDecoder
 	}
 
+	// TxWithTimeoutHeight is used to extract timeouts from sdk.Tx transactions. In the case where,
+	// timeouts are explicitly set on the sdk.Tx, we can use this interface to extract the timeout.
 	TxWithTimeoutHeight interface {
 		sdk.Tx
 
@@ -146,10 +148,10 @@ func (config *DefaultConfig) GetBundledTransactions(tx sdk.Tx) ([][]byte, error)
 
 // GetTimeout defines a default function that returns the timeout of an auction transaction.
 func (config *DefaultConfig) GetTimeout(tx sdk.Tx) (uint64, error) {
-	auctionTx, ok := tx.(TxWithTimeoutHeight)
+	timeoutTx, ok := tx.(TxWithTimeoutHeight)
 	if !ok {
 		return 0, fmt.Errorf("transaction does not implement TxWithTimeoutHeight")
 	}
 
-	return auctionTx.GetTimeoutHeight(), nil
+	return timeoutTx.GetTimeoutHeight(), nil
 }

--- a/mempool/config.go
+++ b/mempool/config.go
@@ -12,6 +12,7 @@ type (
 		Bidder       sdk.AccAddress
 		Bid          sdk.Coin
 		Transactions [][]byte
+		Timeout      uint64
 	}
 
 	// Config defines the configuration for processing auction transactions. It is
@@ -39,9 +40,8 @@ type (
 		// that the user wants to execute at the top of the block given an auction transaction.
 		GetBundledTransactions(tx sdk.Tx) ([][]byte, error)
 
-		// HasValidTimeout defines a function that returns true iff the auction transaction
-		// has a valid timeout.
-		HasValidTimeout(ctx sdk.Context, tx sdk.Tx) error
+		// GetTimeout defines a function that returns the timeout of an auction transaction.
+		GetTimeout(tx sdk.Tx) (uint64, error)
 	}
 
 	// DefaultConfig defines a default configuration for processing auction transactions.
@@ -144,21 +144,12 @@ func (config *DefaultConfig) GetBundledTransactions(tx sdk.Tx) ([][]byte, error)
 	return msg.Transactions, nil
 }
 
-// HasValidTimeout returns true if the transaction has a valid timeout height.
-func (config DefaultConfig) HasValidTimeout(ctx sdk.Context, tx sdk.Tx) error {
+// GetTimeout defines a default function that returns the timeout of an auction transaction.
+func (config *DefaultConfig) GetTimeout(tx sdk.Tx) (uint64, error) {
 	auctionTx, ok := tx.(TxWithTimeoutHeight)
 	if !ok {
-		return fmt.Errorf("transaction does not implement TxWithTimeoutHeight")
+		return 0, fmt.Errorf("transaction does not implement TxWithTimeoutHeight")
 	}
 
-	timeout := auctionTx.GetTimeoutHeight()
-	if timeout == 0 {
-		return fmt.Errorf("timeout height cannot be zero")
-	}
-
-	if timeout < uint64(ctx.BlockHeight()) {
-		return fmt.Errorf("timeout height cannot be less than the current block height")
-	}
-
-	return nil
+	return auctionTx.GetTimeoutHeight(), nil
 }

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -44,15 +44,15 @@ type AuctionMempool struct {
 
 // AuctionTxPriority returns a TxPriority over auction bid transactions only. It
 // is to be used in the auction index only.
-func AuctionTxPriority() TxPriority[string] {
+func AuctionTxPriority(config Config) TxPriority[string] {
 	return TxPriority[string]{
 		GetTxPriority: func(goCtx context.Context, tx sdk.Tx) string {
-			msgAuctionBid, err := GetMsgAuctionBidFromTx(tx)
+			bid, err := config.GetBid(tx)
 			if err != nil {
 				panic(err)
 			}
 
-			return msgAuctionBid.Bid.String()
+			return bid.String()
 		},
 		Compare: func(a, b string) int {
 			aCoins, _ := sdk.ParseCoinsNormalized(a)
@@ -95,7 +95,7 @@ func NewAuctionMempool(txDecoder sdk.TxDecoder, txEncoder sdk.TxEncoder, maxTx i
 		),
 		auctionIndex: NewPriorityMempool(
 			PriorityNonceMempoolConfig[string]{
-				TxPriority: AuctionTxPriority(),
+				TxPriority: AuctionTxPriority(config),
 				MaxTx:      maxTx,
 			},
 		),

--- a/mempool/tx.go
+++ b/mempool/tx.go
@@ -73,13 +73,13 @@ func (am *AuctionMempool) GetBundledTransactions(tx sdk.Tx) ([][]byte, error) {
 	return am.config.GetBundledTransactions(tx)
 }
 
-// HasValidTimeout returns true if the auction transaction has a valid timeout.
-func (am *AuctionMempool) HasValidTimeout(ctx sdk.Context, tx sdk.Tx) error {
+// GetTimeout returns the timeout of an auction transaction.
+func (am *AuctionMempool) GetTimeout(tx sdk.Tx) (uint64, error) {
 	if isAuctionTx, err := am.IsAuctionTx(tx); err != nil || !isAuctionTx {
-		return fmt.Errorf("transaction is not an auction transaction")
+		return 0, fmt.Errorf("transaction is not an auction transaction")
 	}
 
-	return am.config.HasValidTimeout(ctx, tx)
+	return am.config.GetTimeout(tx)
 }
 
 // GetBundleSigners returns all of the signers for each transaction in the bundle.

--- a/mempool/tx.go
+++ b/mempool/tx.go
@@ -73,6 +73,15 @@ func (am *AuctionMempool) GetBundledTransactions(tx sdk.Tx) ([][]byte, error) {
 	return am.config.GetBundledTransactions(tx)
 }
 
+// HasValidTimeout returns true if the auction transaction has a valid timeout.
+func (am *AuctionMempool) HasValidTimeout(ctx sdk.Context, tx sdk.Tx) error {
+	if isAuctionTx, err := am.IsAuctionTx(tx); err != nil || !isAuctionTx {
+		return fmt.Errorf("transaction is not an auction transaction")
+	}
+
+	return am.config.HasValidTimeout(ctx, tx)
+}
+
 // GetBundleSigners returns all of the signers for each transaction in the bundle.
 func (am *AuctionMempool) GetBundleSigners(txs [][]byte) ([]map[string]struct{}, error) {
 	signers := make([]map[string]struct{}, len(txs))


### PR DESCRIPTION
## Overview
As a part of the interface config refactor, we need to allow timeouts to be configurable. We might expect different ways of setting timeouts depending on the app chain POB gets integrated into. In the case of Berachain, timeouts are explicitly set in the precompile contract. Users are unable to set timeouts directly on the `sdk.Tx`.

Also small fix to the `AuctionTxPriority` so bids can be extracted according to the preferences of the app instead of only `MsgAuctionBid`. 