### PR TITLE
fix: Removing normal transactions using RemoveWithoutRefTx

### DIFF
--- a/abci/abci.go
+++ b/abci/abci.go
@@ -21,7 +21,6 @@ type (
 		GetBundledTransactions(tx sdk.Tx) ([][]byte, error)
 		WrapBundleTransaction(tx []byte) (sdk.Tx, error)
 		IsAuctionTx(tx sdk.Tx) (bool, error)
-		RemoveWithoutRefTx(tx sdk.Tx) error
 	}
 
 	ProposalHandler struct {
@@ -277,7 +276,7 @@ func (h *ProposalHandler) verifyTx(ctx sdk.Context, tx sdk.Tx) error {
 }
 
 func (h *ProposalHandler) RemoveTx(tx sdk.Tx) {
-	if err := h.mempool.RemoveWithoutRefTx(tx); err != nil && !errors.Is(err, sdkmempool.ErrTxNotFound) {
+	if err := h.mempool.Remove(tx); err != nil && !errors.Is(err, sdkmempool.ErrTxNotFound) {
 		panic(fmt.Errorf("failed to remove invalid transaction from the mempool: %w", err))
 	}
 }

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -106,9 +106,7 @@ func NewAuctionMempool(txDecoder sdk.TxDecoder, txEncoder sdk.TxEncoder, maxTx i
 	}
 }
 
-// Insert inserts a transaction into the mempool. If the transaction is a special
-// auction tx (tx that contains a single MsgAuctionBid), it will also insert the
-// transaction into the auction index.
+// Insert inserts a transaction into the mempool based on the transaction type (normal or auction).
 func (am *AuctionMempool) Insert(ctx context.Context, tx sdk.Tx) error {
 	isAuctionTx, err := am.IsAuctionTx(tx)
 	if err != nil {
@@ -137,9 +135,7 @@ func (am *AuctionMempool) Insert(ctx context.Context, tx sdk.Tx) error {
 	return nil
 }
 
-// Remove removes a transaction from the mempool. If the transaction is a special
-// auction tx (tx that contains a single MsgAuctionBid), it will also remove all
-// referenced transactions from the global mempool.
+// Remove removes a transaction from the mempool based on the transaction type (normal or auction).
 func (am *AuctionMempool) Remove(tx sdk.Tx) error {
 	isAuctionTx, err := am.IsAuctionTx(tx)
 	if err != nil {
@@ -152,41 +148,6 @@ func (am *AuctionMempool) Remove(tx sdk.Tx) error {
 		am.removeTx(am.globalIndex, tx)
 	case isAuctionTx:
 		am.removeTx(am.auctionIndex, tx)
-
-		// Remove all referenced transactions from the global mempool.
-		bundleTxs, err := am.GetBundledTransactions(tx)
-		if err != nil {
-			return err
-		}
-
-		for _, refTx := range bundleTxs {
-			wrappedRefTx, err := am.WrapBundleTransaction(refTx)
-			if err != nil {
-				return err
-			}
-
-			am.removeTx(am.globalIndex, wrappedRefTx)
-		}
-	}
-
-	return nil
-}
-
-// RemoveWithoutRefTx removes a transaction from the mempool without removing
-// any referenced transactions. Referenced transactions only exist in special
-// auction transactions (txs that only include a single MsgAuctionBid). This
-// API is used to ensure that searchers are unable to remove valid transactions
-// from the global mempool.
-func (am *AuctionMempool) RemoveWithoutRefTx(tx sdk.Tx) error {
-	isAuctionTx, err := am.IsAuctionTx(tx)
-	if err != nil {
-		return err
-	}
-
-	if isAuctionTx {
-		am.removeTx(am.auctionIndex, tx)
-	} else {
-		am.removeTx(am.globalIndex, tx)
 	}
 
 	return nil

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -185,6 +185,8 @@ func (am *AuctionMempool) RemoveWithoutRefTx(tx sdk.Tx) error {
 
 	if isAuctionTx {
 		am.removeTx(am.auctionIndex, tx)
+	} else {
+		am.removeTx(am.globalIndex, tx)
 	}
 
 	return nil


### PR DESCRIPTION
## Overview
Currently, we only remove transactions using `RemoveWithoutRefTx` if the transaction is a auction transaction. This is problematic because in the proposal handlers we expect it to be able to remove normal transactions if a transaction fails `verifyTx`. This means that normal transactions will persist in the mempool even if they are invalid.