### PR TITLE
fix(audit): Min Bid Increment (Audit Issue 2)

### DIFF
--- a/x/builder/keeper/auction.go
+++ b/x/builder/keeper/auction.go
@@ -69,9 +69,19 @@ func (k Keeper) ValidateAuctionBid(ctx sdk.Context, bidder sdk.AccAddress, bid, 
 			return err
 		}
 
+		if minBidIncrement.Denom != bid.Denom {
+			return fmt.Errorf("min bid increment denom (%s) does not match the bid denom (%s)", minBidIncrement, bid)
+		}
+
 		minBid := highestBid.Add(minBidIncrement)
 		if !bid.IsGTE(minBid) {
-			return fmt.Errorf("bid amount (%s) is less than the highest bid (%s) + min bid increment (%s)", bid, highestBid, minBidIncrement)
+			return fmt.Errorf(
+				"bid amount (%s) is less than the highest bid (%s) + min bid increment (%s); smallest acceptable bid is (%s)",
+				bid,
+				highestBid,
+				minBidIncrement,
+				minBid,
+			)
 		}
 	}
 

--- a/x/builder/keeper/auction_test.go
+++ b/x/builder/keeper/auction_test.go
@@ -141,6 +141,15 @@ func (suite *KeeperTestSuite) TestValidateBidInfo() {
 			},
 			false,
 		},
+		{
+			"min bid increment is different from bid denom", // THIS SHOULD NEVER HAPPEN
+			func() {
+				highestBid = sdk.NewCoin("foo", sdk.NewInt(500))
+				bid = sdk.NewCoin("foo", sdk.NewInt(1500))
+				minBidIncrement = sdk.NewCoin("foo2", sdk.NewInt(1000))
+			},
+			false,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
### Overview
Although it's technically not possible for the fees to be of different denoms as we enforce that check on init genesis when validating the param set + any subsequent update to the param set, I have added an extra check in the `ValidateBidInfo` function that ensures the bid denoms match. Also added an additional test case for this.