### PR TITLE
fix(audit): Minimum Bid Increment must be greater than 0 (Audit Issue 3)

### DIFF
--- a/x/builder/types/msgs_test.go
+++ b/x/builder/types/msgs_test.go
@@ -148,6 +148,19 @@ func TestMsgUpdateParams(t *testing.T) {
 			},
 			expectPass: false,
 		},
+		{
+			description: "invalid message with min bid increment equal to 0",
+			msg: types.MsgUpdateParams{
+				Authority: sdk.AccAddress([]byte("test")).String(),
+				Params: types.Params{
+					ProposerFee:          sdk.NewDec(1),
+					EscrowAccountAddress: sdk.AccAddress([]byte("test")).String(),
+					ReserveFee:           sdk.NewCoin("test", sdk.NewInt(100)),
+					MinBidIncrement:      sdk.NewCoin("test", sdk.NewInt(0)),
+				},
+			},
+			expectPass: false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/x/builder/types/params.go
+++ b/x/builder/types/params.go
@@ -58,6 +58,11 @@ func (p Params) Validate() error {
 		return fmt.Errorf("invalid minimum bid increment (%s)", err)
 	}
 
+	// Minimum bid increment must always be greater than 0.
+	if p.MinBidIncrement.IsLTE(sdk.NewCoin(p.MinBidIncrement.Denom, sdk.ZeroInt())) {
+		return fmt.Errorf("minimum bid increment cannot be zero")
+	}
+
 	denoms := map[string]struct{}{
 		p.ReserveFee.Denom:      {},
 		p.MinBidIncrement.Denom: {},


### PR DESCRIPTION
### Overview
This PR updates the param set validation to ensure that minimum bid increment is always greater than 0. I added a test case for verification.