### PR TITLE
fix(audit): Passing the correct CLI context (Audit Issue 4)

### DIFF
--- a/x/builder/client/cli/query.go
+++ b/x/builder/client/cli/query.go
@@ -34,7 +34,11 @@ func CmdQueryParams() *cobra.Command {
 		Short: "Query the current parameters of the builder module",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
 			queryClient := types.NewQueryClient(clientCtx)
 
 			request := &types.QueryParamsRequest{}


### PR DESCRIPTION
### Overview
In this PR, I modify the context that is requested when a query CLI command is executed.