### PR TITLE
fix(audit): Gas Optimization (Audit Issue 7)

### DIFF
--- a/abci/abci_test.go
+++ b/abci/abci_test.go
@@ -52,7 +52,7 @@ type ABCITestSuite struct {
 
 	// account set up
 	accounts []testutils.Account
-	balances sdk.Coins
+	balance  sdk.Coin
 	random   *rand.Rand
 	nonces   map[string]uint64
 }
@@ -101,7 +101,7 @@ func (suite *ABCITestSuite) SetupTest() {
 
 	// Accounts set up
 	suite.accounts = testutils.RandomAccounts(suite.random, 1)
-	suite.balances = sdk.NewCoins(sdk.NewCoin("foo", sdk.NewInt(1000000000000000000)))
+	suite.balance = sdk.NewCoin("foo", sdk.NewInt(1000000000000000000))
 	suite.nonces = make(map[string]uint64)
 	for _, acc := range suite.accounts {
 		suite.nonces[acc.Address.String()] = 0
@@ -114,7 +114,7 @@ func (suite *ABCITestSuite) SetupTest() {
 
 func (suite *ABCITestSuite) anteHandler(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) {
 	signer := tx.GetMsgs()[0].GetSigners()[0]
-	suite.bankKeeper.EXPECT().GetAllBalances(ctx, signer).AnyTimes().Return(suite.balances)
+	suite.bankKeeper.EXPECT().GetBalance(ctx, signer, suite.balance.Denom).AnyTimes().Return(suite.balance)
 
 	next := func(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) {
 		return ctx, nil

--- a/testutils/mocks.go
+++ b/testutils/mocks.go
@@ -58,16 +58,16 @@ func (m *MockBankKeeper) EXPECT() *MockBankKeeperMockRecorder {
 	return m.recorder
 }
 
-func (m *MockBankKeeper) GetAllBalances(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins {
+func (m *MockBankKeeper) GetBalance(ctx sdk.Context, addr sdk.AccAddress, denom string) sdk.Coin {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllBalances", ctx, addr)
-	ret0 := ret[0].(sdk.Coins)
+	ret := m.ctrl.Call(m, "GetBalance", ctx, addr, denom)
+	ret0 := ret[0].(sdk.Coin)
 	return ret0
 }
 
-func (mr *MockBankKeeperMockRecorder) GetAllBalances(ctx, addr interface{}) *gomock.Call {
+func (mr *MockBankKeeperMockRecorder) GetBalance(ctx, addr, denom interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllBalances", reflect.TypeOf((*MockBankKeeper)(nil).GetAllBalances), ctx, addr)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBalance", reflect.TypeOf((*MockBankKeeper)(nil).GetBalance), ctx, addr, denom)
 }
 
 func (m *MockBankKeeper) SendCoins(ctx sdk.Context, fromAddr sdk.AccAddress, toAddr sdk.AccAddress, amt sdk.Coins) error {

--- a/x/builder/ante/ante_test.go
+++ b/x/builder/ante/ante_test.go
@@ -69,9 +69,9 @@ func (suite *AnteTestSuite) SetupTest() {
 	suite.Require().NoError(err)
 }
 
-func (suite *AnteTestSuite) executeAnteHandler(tx sdk.Tx, balance sdk.Coins) (sdk.Context, error) {
+func (suite *AnteTestSuite) executeAnteHandler(tx sdk.Tx, balance sdk.Coin) (sdk.Context, error) {
 	signer := tx.GetMsgs()[0].GetSigners()[0]
-	suite.bankKeeper.EXPECT().GetAllBalances(suite.ctx, signer).AnyTimes().Return(balance)
+	suite.bankKeeper.EXPECT().GetBalance(suite.ctx, signer, balance.Denom).AnyTimes().Return(balance)
 
 	next := func(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) {
 		return ctx, nil
@@ -85,7 +85,7 @@ func (suite *AnteTestSuite) TestAnteHandler() {
 		// Bid set up
 		bidder  = testutils.RandomAccounts(suite.random, 1)[0]
 		bid     = sdk.NewCoin("foo", sdk.NewInt(1000))
-		balance = sdk.NewCoins(sdk.NewCoin("foo", sdk.NewInt(10000)))
+		balance = sdk.NewCoin("foo", sdk.NewInt(10000))
 		signers = []testutils.Account{bidder}
 
 		// Top bidding auction tx set up
@@ -125,14 +125,14 @@ func (suite *AnteTestSuite) TestAnteHandler() {
 			"bidder has insufficient balance, invalid auction tx",
 			func() {
 				insertTopBid = false
-				balance = sdk.NewCoins(sdk.NewCoin("foo", sdk.NewInt(10)))
+				balance = sdk.NewCoin("foo", sdk.NewInt(10))
 			},
 			false,
 		},
 		{
 			"bid is smaller than reserve fee, invalid auction tx",
 			func() {
-				balance = sdk.NewCoins(sdk.NewCoin("foo", sdk.NewInt(10000)))
+				balance = sdk.NewCoin("foo", sdk.NewInt(10000))
 				bid = sdk.NewCoin("foo", sdk.NewInt(101))
 				reserveFee = sdk.NewCoin("foo", sdk.NewInt(1000))
 			},
@@ -141,7 +141,7 @@ func (suite *AnteTestSuite) TestAnteHandler() {
 		{
 			"valid auction bid tx",
 			func() {
-				balance = sdk.NewCoins(sdk.NewCoin("foo", sdk.NewInt(10000)))
+				balance = sdk.NewCoin("foo", sdk.NewInt(10000))
 				bid = sdk.NewCoin("foo", sdk.NewInt(1000))
 				reserveFee = sdk.NewCoin("foo", sdk.NewInt(100))
 			},
@@ -158,7 +158,7 @@ func (suite *AnteTestSuite) TestAnteHandler() {
 			"auction tx is the top bidding tx",
 			func() {
 				timeout = 1000
-				balance = sdk.NewCoins(sdk.NewCoin("foo", sdk.NewInt(10000)))
+				balance = sdk.NewCoin("foo", sdk.NewInt(10000))
 				bid = sdk.NewCoin("foo", sdk.NewInt(1000))
 				reserveFee = sdk.NewCoin("foo", sdk.NewInt(100))
 

--- a/x/builder/keeper/auction.go
+++ b/x/builder/keeper/auction.go
@@ -86,8 +86,8 @@ func (k Keeper) ValidateAuctionBid(ctx sdk.Context, bidder sdk.AccAddress, bid, 
 	}
 
 	// ensure the bidder has enough funds to cover all the inclusion fees
-	balances := k.bankKeeper.GetAllBalances(ctx, bidder)
-	if !balances.IsAllGTE(sdk.NewCoins(bid)) {
+	balances := k.bankKeeper.GetBalance(ctx, bidder, bid.Denom)
+	if !balances.IsGTE(bid) {
 		return fmt.Errorf("insufficient funds to bid %s with balance %s", bid, balances)
 	}
 

--- a/x/builder/keeper/auction_test.go
+++ b/x/builder/keeper/auction_test.go
@@ -15,7 +15,7 @@ func (suite *KeeperTestSuite) TestValidateBidInfo() {
 	var (
 		// Tx building variables
 		accounts = []testutils.Account{} // tracks the order of signers in the bundle
-		balance  = sdk.NewCoins(sdk.NewCoin("foo", sdk.NewInt(10000)))
+		balance  = sdk.NewCoin("foo", sdk.NewInt(10000))
 		bid      = sdk.NewCoin("foo", sdk.NewInt(1000))
 
 		// Auction params
@@ -48,7 +48,7 @@ func (suite *KeeperTestSuite) TestValidateBidInfo() {
 			"insufficient balance",
 			func() {
 				bid = sdk.NewCoin("foo", sdk.NewInt(1000))
-				balance = sdk.NewCoins()
+				balance = sdk.NewCoin("foo", sdk.NewInt(0))
 			},
 			false,
 		},
@@ -57,7 +57,7 @@ func (suite *KeeperTestSuite) TestValidateBidInfo() {
 			func() {
 				// reset the balance and bid to their original values
 				bid = sdk.NewCoin("foo", sdk.NewInt(1000))
-				balance = sdk.NewCoins(sdk.NewCoin("foo", sdk.NewInt(10000)))
+				balance = sdk.NewCoin("foo", sdk.NewInt(10000))
 				accounts = testutils.RandomAccounts(rnd, int(maxBundleSize+1))
 			},
 			false,
@@ -159,7 +159,7 @@ func (suite *KeeperTestSuite) TestValidateBidInfo() {
 			tc.malleate()
 
 			// Set up the new builder keeper with mocks customized for this test case
-			suite.bankKeeper.EXPECT().GetAllBalances(suite.ctx, bidder.Address).Return(balance).AnyTimes()
+			suite.bankKeeper.EXPECT().GetBalance(suite.ctx, bidder.Address, minBidIncrement.Denom).Return(balance).AnyTimes()
 			suite.bankKeeper.EXPECT().SendCoins(suite.ctx, bidder.Address, escrowAddress, reserveFee).Return(nil).AnyTimes()
 
 			suite.builderKeeper = keeper.NewKeeper(

--- a/x/builder/types/expected_keepers.go
+++ b/x/builder/types/expected_keepers.go
@@ -13,7 +13,7 @@ type AccountKeeper interface {
 // BankKeeper defines the expected API contract for the x/bank module.
 type BankKeeper interface {
 	SendCoins(ctx sdk.Context, fromAddr sdk.AccAddress, toAddr sdk.AccAddress, amt sdk.Coins) error
-	GetAllBalances(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
+	GetBalance(ctx sdk.Context, addr sdk.AccAddress, denom string) sdk.Coin
 }
 
 // DistributionKeeper defines the expected API contract for the x/distribution


### PR DESCRIPTION
### Overview
Per audit recommendation, we can decrease gas consumption by only requesting the balance of the bid denom. Additionally, we can successfully query all module parameters in a single request instead of multiple in the msg server.