### PR TITLE
fix(audit): Error consistency (Audit Issue 8)

### DIFF
--- a/x/builder/keeper/auction.go
+++ b/x/builder/keeper/auction.go
@@ -124,7 +124,7 @@ func (k Keeper) ValidateAuctionBundle(bidder sdk.AccAddress, bundleSigners []map
 		// as long as all subsequent transactions are signed by the bidder.
 		if len(prevSigners) == 0 {
 			if seenBidder {
-				return fmt.Errorf("bundle contains transactions signed by multiple parties; possible front-running or sandwich attack")
+				return NewFrontRunningError()
 			}
 
 			seenBidder = true
@@ -132,7 +132,7 @@ func (k Keeper) ValidateAuctionBundle(bidder sdk.AccAddress, bundleSigners []map
 			filterSigners(prevSigners, txSigners)
 
 			if len(prevSigners) == 0 {
-				return fmt.Errorf("bundle contains transactions signed by multiple parties; possible front-running or sandwich attack")
+				return NewFrontRunningError()
 			}
 		}
 	}

--- a/x/builder/keeper/errors.go
+++ b/x/builder/keeper/errors.go
@@ -1,0 +1,12 @@
+package keeper
+
+// FrontRunningError defines a custom error type for detecting front-running or sandwich attacks.
+type FrontRunningError struct{}
+
+func NewFrontRunningError() *FrontRunningError {
+	return &FrontRunningError{}
+}
+
+func (e FrontRunningError) Error() string {
+	return "bundle contains transactions signed by multiple parties; possible front-running or sandwich attack"
+}


### PR DESCRIPTION
### Overview
Moving the front running error into a single unified error type that can be easily modified if desired.