### PR TITLE
feat: Provide Configuration Options for POB

### DIFF
--- a/abci/abci_test.go
+++ b/abci/abci_test.go
@@ -114,8 +114,6 @@ func (suite *ABCITestSuite) SetupTest() {
 		suite.key,
 		suite.accountKeeper,
 		suite.bankKeeper,
-		suite.distrKeeper,
-		suite.stakingKeeper,
 		suite.rewardsAddressProvider,
 		suite.authorityAccount.String(),
 	)

--- a/abci/abci_test.go
+++ b/abci/abci_test.go
@@ -18,7 +18,7 @@ import (
 	testutils "github.com/skip-mev/pob/testutils"
 	"github.com/skip-mev/pob/x/builder/ante"
 	"github.com/skip-mev/pob/x/builder/keeper"
-	"github.com/skip-mev/pob/x/builder/rewards_address_provider"
+	rewardsaddressprovider "github.com/skip-mev/pob/x/builder/rewards_address_provider"
 	buildertypes "github.com/skip-mev/pob/x/builder/types"
 	"github.com/stretchr/testify/suite"
 )
@@ -43,7 +43,7 @@ type ABCITestSuite struct {
 	accountKeeper          *testutils.MockAccountKeeper
 	distrKeeper            *testutils.MockDistributionKeeper
 	stakingKeeper          *testutils.MockStakingKeeper
-	rewardsAddressProvider rewards_address_provider.RewardsAddressProvider
+	rewardsAddressProvider rewardsaddressprovider.RewardsAddressProvider
 	builderDecorator       ante.BuilderDecorator
 	key                    *storetypes.KVStoreKey
 	authorityAccount       sdk.AccAddress
@@ -103,7 +103,7 @@ func (suite *ABCITestSuite) SetupTest() {
 	suite.distrKeeper = testutils.NewMockDistributionKeeper(ctrl)
 	suite.stakingKeeper = testutils.NewMockStakingKeeper(ctrl)
 	suite.authorityAccount = sdk.AccAddress([]byte("authority"))
-	suite.rewardsAddressProvider = rewards_address_provider.NewProposerRewardsAddressProvider(
+	suite.rewardsAddressProvider = rewardsaddressprovider.NewProposerRewardsAddressProvider(
 		suite.distrKeeper,
 		suite.stakingKeeper,
 	)

--- a/blockbuster/abci/abci_test.go
+++ b/blockbuster/abci/abci_test.go
@@ -18,7 +18,7 @@ import (
 	testutils "github.com/skip-mev/pob/testutils"
 	"github.com/skip-mev/pob/x/builder/ante"
 	"github.com/skip-mev/pob/x/builder/keeper"
-	"github.com/skip-mev/pob/x/builder/rewards_address_provider"
+	rewardsaddressprovider "github.com/skip-mev/pob/x/builder/rewards_address_provider"
 	buildertypes "github.com/skip-mev/pob/x/builder/types"
 	"github.com/stretchr/testify/suite"
 
@@ -59,7 +59,7 @@ type ABCITestSuite struct {
 	accountKeeper          *testutils.MockAccountKeeper
 	distrKeeper            *testutils.MockDistributionKeeper
 	stakingKeeper          *testutils.MockStakingKeeper
-	rewardsAddressProvider rewards_address_provider.RewardsAddressProvider
+	rewardsAddressProvider rewardsaddressprovider.RewardsAddressProvider
 	builderDecorator       ante.BuilderDecorator
 }
 
@@ -124,7 +124,7 @@ func (suite *ABCITestSuite) SetupTest() {
 	suite.bankKeeper = testutils.NewMockBankKeeper(ctrl)
 	suite.distrKeeper = testutils.NewMockDistributionKeeper(ctrl)
 	suite.stakingKeeper = testutils.NewMockStakingKeeper(ctrl)
-	suite.rewardsAddressProvider = rewards_address_provider.NewProposerRewardsAddressProvider(
+	suite.rewardsAddressProvider = rewardsaddressprovider.NewProposerRewardsAddressProvider(
 		suite.distrKeeper,
 		suite.stakingKeeper,
 	)

--- a/blockbuster/abci/abci_test.go
+++ b/blockbuster/abci/abci_test.go
@@ -135,8 +135,6 @@ func (suite *ABCITestSuite) SetupTest() {
 		key,
 		suite.accountKeeper,
 		suite.bankKeeper,
-		suite.distrKeeper,
-		suite.stakingKeeper,
 		suite.rewardsAddressProvider,
 		sdk.AccAddress([]byte("authority")).String(),
 	)

--- a/blockbuster/abci/abci_test.go
+++ b/blockbuster/abci/abci_test.go
@@ -18,6 +18,7 @@ import (
 	testutils "github.com/skip-mev/pob/testutils"
 	"github.com/skip-mev/pob/x/builder/ante"
 	"github.com/skip-mev/pob/x/builder/keeper"
+	"github.com/skip-mev/pob/x/builder/rewards_address_provider"
 	buildertypes "github.com/skip-mev/pob/x/builder/types"
 	"github.com/stretchr/testify/suite"
 
@@ -53,12 +54,13 @@ type ABCITestSuite struct {
 	nonces   map[string]uint64
 
 	// Keeper set up
-	builderKeeper    keeper.Keeper
-	bankKeeper       *testutils.MockBankKeeper
-	accountKeeper    *testutils.MockAccountKeeper
-	distrKeeper      *testutils.MockDistributionKeeper
-	stakingKeeper    *testutils.MockStakingKeeper
-	builderDecorator ante.BuilderDecorator
+	builderKeeper          keeper.Keeper
+	bankKeeper             *testutils.MockBankKeeper
+	accountKeeper          *testutils.MockAccountKeeper
+	distrKeeper            *testutils.MockDistributionKeeper
+	stakingKeeper          *testutils.MockStakingKeeper
+	rewardsAddressProvider rewards_address_provider.RewardsAddressProvider
+	builderDecorator       ante.BuilderDecorator
 }
 
 func TestBlockBusterTestSuite(t *testing.T) {
@@ -122,6 +124,10 @@ func (suite *ABCITestSuite) SetupTest() {
 	suite.bankKeeper = testutils.NewMockBankKeeper(ctrl)
 	suite.distrKeeper = testutils.NewMockDistributionKeeper(ctrl)
 	suite.stakingKeeper = testutils.NewMockStakingKeeper(ctrl)
+	suite.rewardsAddressProvider = rewards_address_provider.NewProposerRewardsAddressProvider(
+		suite.distrKeeper,
+		suite.stakingKeeper,
+	)
 
 	// Builder keeper / decorator set up
 	suite.builderKeeper = keeper.NewKeeper(
@@ -131,6 +137,7 @@ func (suite *ABCITestSuite) SetupTest() {
 		suite.bankKeeper,
 		suite.distrKeeper,
 		suite.stakingKeeper,
+		suite.rewardsAddressProvider,
 		sdk.AccAddress([]byte("authority")).String(),
 	)
 

--- a/x/builder/ante/ante_test.go
+++ b/x/builder/ante/ante_test.go
@@ -78,8 +78,6 @@ func (suite *AnteTestSuite) SetupTest() {
 		suite.key,
 		suite.accountKeeper,
 		suite.bankKeeper,
-		suite.distrKeeper,
-		suite.stakingKeeper,
 		suite.rewardsAddressProvider,
 		suite.authorityAccount.String(),
 	)

--- a/x/builder/ante/ante_test.go
+++ b/x/builder/ante/ante_test.go
@@ -15,7 +15,7 @@ import (
 	testutils "github.com/skip-mev/pob/testutils"
 	"github.com/skip-mev/pob/x/builder/ante"
 	"github.com/skip-mev/pob/x/builder/keeper"
-	"github.com/skip-mev/pob/x/builder/rewards_address_provider"
+	rewardsaddressprovider "github.com/skip-mev/pob/x/builder/rewards_address_provider"
 	buildertypes "github.com/skip-mev/pob/x/builder/types"
 	"github.com/stretchr/testify/suite"
 )
@@ -33,7 +33,7 @@ type AnteTestSuite struct {
 	accountKeeper          *testutils.MockAccountKeeper
 	distrKeeper            *testutils.MockDistributionKeeper
 	stakingKeeper          *testutils.MockStakingKeeper
-	rewardsAddressProvider rewards_address_provider.RewardsAddressProvider
+	rewardsAddressProvider rewardsaddressprovider.RewardsAddressProvider
 	builderDecorator       ante.BuilderDecorator
 	key                    *storetypes.KVStoreKey
 	authorityAccount       sdk.AccAddress
@@ -68,7 +68,7 @@ func (suite *AnteTestSuite) SetupTest() {
 	suite.distrKeeper = testutils.NewMockDistributionKeeper(ctrl)
 	suite.stakingKeeper = testutils.NewMockStakingKeeper(ctrl)
 	suite.authorityAccount = sdk.AccAddress([]byte("authority"))
-	suite.rewardsAddressProvider = rewards_address_provider.NewProposerRewardsAddressProvider(
+	suite.rewardsAddressProvider = rewardsaddressprovider.NewProposerRewardsAddressProvider(
 		suite.distrKeeper,
 		suite.stakingKeeper,
 	)

--- a/x/builder/keeper/auction_test.go
+++ b/x/builder/keeper/auction_test.go
@@ -166,8 +166,6 @@ func (suite *KeeperTestSuite) TestValidateBidInfo() {
 				suite.key,
 				suite.accountKeeper,
 				suite.bankKeeper,
-				suite.distrKeeper,
-				suite.stakingKeeper,
 				suite.rewardsAddressProvider,
 				suite.authorityAccount.String(),
 			)

--- a/x/builder/keeper/auction_test.go
+++ b/x/builder/keeper/auction_test.go
@@ -168,6 +168,7 @@ func (suite *KeeperTestSuite) TestValidateBidInfo() {
 				suite.bankKeeper,
 				suite.distrKeeper,
 				suite.stakingKeeper,
+				suite.rewardsAddressProvider,
 				suite.authorityAccount.String(),
 			)
 			params := types.Params{

--- a/x/builder/keeper/keeper.go
+++ b/x/builder/keeper/keeper.go
@@ -9,7 +9,7 @@ import (
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/skip-mev/pob/x/builder/rewards_address_provider"
+	rewardsaddressprovider "github.com/skip-mev/pob/x/builder/rewards_address_provider"
 	"github.com/skip-mev/pob/x/builder/types"
 )
 
@@ -18,7 +18,7 @@ type Keeper struct {
 	storeKey storetypes.StoreKey
 
 	bankKeeper             types.BankKeeper
-	rewardsAddressProvider rewards_address_provider.RewardsAddressProvider
+	rewardsAddressProvider rewardsaddressprovider.RewardsAddressProvider
 
 	// The address that is capable of executing a MsgUpdateParams message.
 	// Typically this will be the governance module's address.
@@ -30,7 +30,7 @@ func NewKeeper(
 	storeKey storetypes.StoreKey,
 	accountKeeper types.AccountKeeper,
 	bankKeeper types.BankKeeper,
-	rewardsAddressProvider rewards_address_provider.RewardsAddressProvider,
+	rewardsAddressProvider rewardsaddressprovider.RewardsAddressProvider,
 	authority string,
 ) Keeper {
 	// Ensure that the authority address is valid.

--- a/x/builder/keeper/keeper.go
+++ b/x/builder/keeper/keeper.go
@@ -8,6 +8,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/skip-mev/pob/x/builder/rewards_address_provider"
 	"github.com/skip-mev/pob/x/builder/types"
 )
 
@@ -15,9 +17,10 @@ type Keeper struct {
 	cdc      codec.BinaryCodec
 	storeKey storetypes.StoreKey
 
-	bankKeeper    types.BankKeeper
-	distrKeeper   types.DistributionKeeper
-	stakingKeeper types.StakingKeeper
+	bankKeeper             types.BankKeeper
+	distrKeeper            types.DistributionKeeper
+	stakingKeeper          types.StakingKeeper
+	rewardsAddressProvider rewards_address_provider.RewardsAddressProvider
 
 	// The address that is capable of executing a MsgUpdateParams message.
 	// Typically this will be the governance module's address.
@@ -31,6 +34,7 @@ func NewKeeper(
 	bankKeeper types.BankKeeper,
 	distrKeeper types.DistributionKeeper,
 	stakingKeeper types.StakingKeeper,
+	rewardsAddressProvider rewards_address_provider.RewardsAddressProvider,
 	authority string,
 ) Keeper {
 	// Ensure that the authority address is valid.
@@ -44,12 +48,13 @@ func NewKeeper(
 	}
 
 	return Keeper{
-		cdc:           cdc,
-		storeKey:      storeKey,
-		bankKeeper:    bankKeeper,
-		distrKeeper:   distrKeeper,
-		stakingKeeper: stakingKeeper,
-		authority:     authority,
+		cdc:                    cdc,
+		storeKey:               storeKey,
+		bankKeeper:             bankKeeper,
+		distrKeeper:            distrKeeper,
+		stakingKeeper:          stakingKeeper,
+		rewardsAddressProvider: rewardsAddressProvider,
+		authority:              authority,
 	}
 }
 

--- a/x/builder/keeper/keeper.go
+++ b/x/builder/keeper/keeper.go
@@ -18,8 +18,6 @@ type Keeper struct {
 	storeKey storetypes.StoreKey
 
 	bankKeeper             types.BankKeeper
-	distrKeeper            types.DistributionKeeper
-	stakingKeeper          types.StakingKeeper
 	rewardsAddressProvider rewards_address_provider.RewardsAddressProvider
 
 	// The address that is capable of executing a MsgUpdateParams message.
@@ -32,8 +30,6 @@ func NewKeeper(
 	storeKey storetypes.StoreKey,
 	accountKeeper types.AccountKeeper,
 	bankKeeper types.BankKeeper,
-	distrKeeper types.DistributionKeeper,
-	stakingKeeper types.StakingKeeper,
 	rewardsAddressProvider rewards_address_provider.RewardsAddressProvider,
 	authority string,
 ) Keeper {
@@ -51,8 +47,6 @@ func NewKeeper(
 		cdc:                    cdc,
 		storeKey:               storeKey,
 		bankKeeper:             bankKeeper,
-		distrKeeper:            distrKeeper,
-		stakingKeeper:          stakingKeeper,
 		rewardsAddressProvider: rewardsAddressProvider,
 		authority:              authority,
 	}

--- a/x/builder/keeper/keeper_test.go
+++ b/x/builder/keeper/keeper_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/golang/mock/gomock"
 	testutils "github.com/skip-mev/pob/testutils"
 	"github.com/skip-mev/pob/x/builder/keeper"
-	"github.com/skip-mev/pob/x/builder/rewards_address_provider"
+	rewardsaddressprovider "github.com/skip-mev/pob/x/builder/rewards_address_provider"
 	"github.com/skip-mev/pob/x/builder/types"
 
 	"github.com/stretchr/testify/suite"
@@ -23,7 +23,7 @@ type KeeperTestSuite struct {
 	accountKeeper          *testutils.MockAccountKeeper
 	distrKeeper            *testutils.MockDistributionKeeper
 	stakingKeeper          *testutils.MockStakingKeeper
-	rewardsAddressProvider rewards_address_provider.RewardsAddressProvider
+	rewardsAddressProvider rewardsaddressprovider.RewardsAddressProvider
 	encCfg                 testutils.EncodingConfig
 	ctx                    sdk.Context
 	msgServer              types.MsgServer
@@ -50,7 +50,7 @@ func (suite *KeeperTestSuite) SetupTest() {
 	suite.distrKeeper = testutils.NewMockDistributionKeeper(ctrl)
 	suite.stakingKeeper = testutils.NewMockStakingKeeper(ctrl)
 	suite.authorityAccount = sdk.AccAddress([]byte("authority"))
-	suite.rewardsAddressProvider = rewards_address_provider.NewProposerRewardsAddressProvider(
+	suite.rewardsAddressProvider = rewardsaddressprovider.NewProposerRewardsAddressProvider(
 		suite.distrKeeper,
 		suite.stakingKeeper,
 	)

--- a/x/builder/keeper/keeper_test.go
+++ b/x/builder/keeper/keeper_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/golang/mock/gomock"
 	testutils "github.com/skip-mev/pob/testutils"
 	"github.com/skip-mev/pob/x/builder/keeper"
+	"github.com/skip-mev/pob/x/builder/rewards_address_provider"
 	"github.com/skip-mev/pob/x/builder/types"
 
 	"github.com/stretchr/testify/suite"
@@ -17,16 +18,17 @@ import (
 type KeeperTestSuite struct {
 	suite.Suite
 
-	builderKeeper    keeper.Keeper
-	bankKeeper       *testutils.MockBankKeeper
-	accountKeeper    *testutils.MockAccountKeeper
-	distrKeeper      *testutils.MockDistributionKeeper
-	stakingKeeper    *testutils.MockStakingKeeper
-	encCfg           testutils.EncodingConfig
-	ctx              sdk.Context
-	msgServer        types.MsgServer
-	key              *storetypes.KVStoreKey
-	authorityAccount sdk.AccAddress
+	builderKeeper          keeper.Keeper
+	bankKeeper             *testutils.MockBankKeeper
+	accountKeeper          *testutils.MockAccountKeeper
+	distrKeeper            *testutils.MockDistributionKeeper
+	stakingKeeper          *testutils.MockStakingKeeper
+	rewardsAddressProvider rewards_address_provider.RewardsAddressProvider
+	encCfg                 testutils.EncodingConfig
+	ctx                    sdk.Context
+	msgServer              types.MsgServer
+	key                    *storetypes.KVStoreKey
+	authorityAccount       sdk.AccAddress
 }
 
 func TestKeeperTestSuite(t *testing.T) {
@@ -48,6 +50,11 @@ func (suite *KeeperTestSuite) SetupTest() {
 	suite.distrKeeper = testutils.NewMockDistributionKeeper(ctrl)
 	suite.stakingKeeper = testutils.NewMockStakingKeeper(ctrl)
 	suite.authorityAccount = sdk.AccAddress([]byte("authority"))
+	suite.rewardsAddressProvider = rewards_address_provider.NewProposerRewardsAddressProvider(
+		suite.distrKeeper,
+		suite.stakingKeeper,
+	)
+
 	suite.builderKeeper = keeper.NewKeeper(
 		suite.encCfg.Codec,
 		suite.key,
@@ -55,6 +62,7 @@ func (suite *KeeperTestSuite) SetupTest() {
 		suite.bankKeeper,
 		suite.distrKeeper,
 		suite.stakingKeeper,
+		suite.rewardsAddressProvider,
 		suite.authorityAccount.String(),
 	)
 

--- a/x/builder/keeper/keeper_test.go
+++ b/x/builder/keeper/keeper_test.go
@@ -60,8 +60,6 @@ func (suite *KeeperTestSuite) SetupTest() {
 		suite.key,
 		suite.accountKeeper,
 		suite.bankKeeper,
-		suite.distrKeeper,
-		suite.stakingKeeper,
 		suite.rewardsAddressProvider,
 		suite.authorityAccount.String(),
 	)

--- a/x/builder/keeper/msg_server.go
+++ b/x/builder/keeper/msg_server.go
@@ -54,14 +54,13 @@ func (m MsgServer) AuctionBid(goCtx context.Context, msg *types.MsgAuctionBid) (
 			return nil, err
 		}
 	} else {
-		prevPropConsAddr := m.distrKeeper.GetPreviousProposerConsAddr(ctx)
-		prevProposer := m.stakingKeeper.ValidatorByConsAddr(ctx, prevPropConsAddr)
+		rewardsAddress := m.rewardsAddressProvider.GetRewardsAddress(ctx)
 
 		// determine the amount of the bid that goes to the (previous) proposer
 		bid := sdk.NewDecCoinsFromCoins(msg.Bid)
 		proposerReward, _ = bid.MulDecTruncate(params.ProposerFee).TruncateDecimal()
 
-		if err := m.bankKeeper.SendCoins(ctx, bidder, sdk.AccAddress(prevProposer.GetOperator()), proposerReward); err != nil {
+		if err := m.bankKeeper.SendCoins(ctx, bidder, rewardsAddress, proposerReward); err != nil {
 			return nil, err
 		}
 

--- a/x/builder/module.go
+++ b/x/builder/module.go
@@ -21,6 +21,7 @@ import (
 	modulev1 "github.com/skip-mev/pob/api/pob/builder/module/v1"
 	"github.com/skip-mev/pob/x/builder/client/cli"
 	"github.com/skip-mev/pob/x/builder/keeper"
+	"github.com/skip-mev/pob/x/builder/rewards_address_provider"
 	"github.com/skip-mev/pob/x/builder/types"
 	"github.com/spf13/cobra"
 )
@@ -144,7 +145,10 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 func init() {
 	appmodule.Register(
 		&modulev1.Module{},
-		appmodule.Provide(ProvideModule),
+		appmodule.Provide(
+			rewards_address_provider.Provide,
+			ProvideModule,
+		),
 	)
 }
 
@@ -155,10 +159,11 @@ type Inputs struct {
 	Cdc    codec.Codec
 	Key    *storetypes.KVStoreKey
 
-	AccountKeeper      types.AccountKeeper
-	BankKeeper         types.BankKeeper
-	DistributionKeeper types.DistributionKeeper
-	StakingKeeper      types.StakingKeeper
+	AccountKeeper          types.AccountKeeper
+	BankKeeper             types.BankKeeper
+	DistributionKeeper     types.DistributionKeeper
+	StakingKeeper          types.StakingKeeper
+	RewardsAddressProvider rewards_address_provider.RewardsAddressProvider
 }
 
 type Outputs struct {
@@ -182,6 +187,7 @@ func ProvideModule(in Inputs) Outputs {
 		in.BankKeeper,
 		in.DistributionKeeper,
 		in.StakingKeeper,
+		in.RewardsAddressProvider,
 		authority.String(),
 	)
 

--- a/x/builder/module.go
+++ b/x/builder/module.go
@@ -161,8 +161,6 @@ type Inputs struct {
 
 	AccountKeeper          types.AccountKeeper
 	BankKeeper             types.BankKeeper
-	DistributionKeeper     types.DistributionKeeper
-	StakingKeeper          types.StakingKeeper
 	RewardsAddressProvider rewards_address_provider.RewardsAddressProvider
 }
 
@@ -185,8 +183,6 @@ func ProvideModule(in Inputs) Outputs {
 		in.Key,
 		in.AccountKeeper,
 		in.BankKeeper,
-		in.DistributionKeeper,
-		in.StakingKeeper,
 		in.RewardsAddressProvider,
 		authority.String(),
 	)

--- a/x/builder/module.go
+++ b/x/builder/module.go
@@ -146,7 +146,7 @@ func init() {
 	appmodule.Register(
 		&modulev1.Module{},
 		appmodule.Provide(
-			rewards_address_provider.ProvideProposerRewards,
+			rewardsaddressprovider.ProvideProposerRewards,
 			ProvideModule,
 		),
 	)
@@ -161,7 +161,7 @@ type Inputs struct {
 
 	AccountKeeper          types.AccountKeeper
 	BankKeeper             types.BankKeeper
-	RewardsAddressProvider rewards_address_provider.RewardsAddressProvider
+	RewardsAddressProvider rewardsaddressprovider.RewardsAddressProvider
 }
 
 type Outputs struct {

--- a/x/builder/module.go
+++ b/x/builder/module.go
@@ -146,7 +146,7 @@ func init() {
 	appmodule.Register(
 		&modulev1.Module{},
 		appmodule.Provide(
-			rewards_address_provider.Provide,
+			rewards_address_provider.ProvideProposerRewards,
 			ProvideModule,
 		),
 	)

--- a/x/builder/rewards_address_provider/fixed_address_rewards_address_provider.go
+++ b/x/builder/rewards_address_provider/fixed_address_rewards_address_provider.go
@@ -1,0 +1,22 @@
+package rewards_address_provider
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// Provides auction profits to a fixed address
+type FixedAddressRewardsAddressProvider struct {
+	rewardsAddress sdk.AccAddress
+}
+
+func NewFixedAddressRewardsAddressProvider(
+	rewardsAddress sdk.AccAddress,
+) RewardsAddressProvider {
+	return &FixedAddressRewardsAddressProvider{
+		rewardsAddress: rewardsAddress,
+	}
+}
+
+func (p *FixedAddressRewardsAddressProvider) GetRewardsAddress(context sdk.Context) sdk.AccAddress {
+	return p.rewardsAddress
+}

--- a/x/builder/rewards_address_provider/fixed_address_rewards_address_provider.go
+++ b/x/builder/rewards_address_provider/fixed_address_rewards_address_provider.go
@@ -1,7 +1,9 @@
 package rewards_address_provider
 
 import (
+	"cosmossdk.io/depinject"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/skip-mev/pob/x/builder/types"
 )
 
 // Provides auction profits to a fixed address
@@ -19,4 +21,26 @@ func NewFixedAddressRewardsAddressProvider(
 
 func (p *FixedAddressRewardsAddressProvider) GetRewardsAddress(context sdk.Context) sdk.AccAddress {
 	return p.rewardsAddress
+}
+
+// Dependency injection
+
+type FixedAddressDepInjectInput struct {
+	depinject.In
+
+	AccountKeeper types.AccountKeeper
+}
+
+type FixedAddressDepInjectOutput struct {
+	depinject.Out
+
+	RewardsAddressProvider RewardsAddressProvider
+}
+
+func ProvideFixedAddress(in FixedAddressDepInjectInput) FixedAddressDepInjectOutput {
+	rewardAddressProvider := NewFixedAddressRewardsAddressProvider(
+		in.AccountKeeper.GetModuleAddress(types.ModuleName),
+	)
+
+	return FixedAddressDepInjectOutput{RewardsAddressProvider: rewardAddressProvider}
 }

--- a/x/builder/rewards_address_provider/fixed_address_rewards_address_provider.go
+++ b/x/builder/rewards_address_provider/fixed_address_rewards_address_provider.go
@@ -1,4 +1,4 @@
-package rewards_address_provider
+package rewardsaddressprovider
 
 import (
 	"cosmossdk.io/depinject"
@@ -19,7 +19,7 @@ func NewFixedAddressRewardsAddressProvider(
 	}
 }
 
-func (p *FixedAddressRewardsAddressProvider) GetRewardsAddress(context sdk.Context) sdk.AccAddress {
+func (p *FixedAddressRewardsAddressProvider) GetRewardsAddress(_ sdk.Context) sdk.AccAddress {
 	return p.rewardsAddress
 }
 

--- a/x/builder/rewards_address_provider/fixed_address_rewards_address_provider.go
+++ b/x/builder/rewards_address_provider/fixed_address_rewards_address_provider.go
@@ -37,7 +37,7 @@ type FixedAddressDepInjectOutput struct {
 	RewardsAddressProvider RewardsAddressProvider
 }
 
-func ProvideFixedAddress(in FixedAddressDepInjectInput) FixedAddressDepInjectOutput {
+func ProvideModuleAddress(in FixedAddressDepInjectInput) FixedAddressDepInjectOutput {
 	rewardAddressProvider := NewFixedAddressRewardsAddressProvider(
 		in.AccountKeeper.GetModuleAddress(types.ModuleName),
 	)

--- a/x/builder/rewards_address_provider/proposer_rewards_address_provider.go
+++ b/x/builder/rewards_address_provider/proposer_rewards_address_provider.go
@@ -32,24 +32,24 @@ func (p *ProposerRewardsAddressProvider) GetRewardsAddress(context sdk.Context) 
 
 // Dependency injection
 
-type DepInjectInput struct {
+type ProposerRewardsDepInjectInput struct {
 	depinject.In
 
 	types.DistributionKeeper
 	types.StakingKeeper
 }
 
-type DepInjectOutput struct {
+type ProposerRewardsDepInjectOutput struct {
 	depinject.Out
 
 	RewardsAddressProvider RewardsAddressProvider
 }
 
-func Provide(in DepInjectInput) DepInjectOutput {
+func ProvideProposerRewards(in ProposerRewardsDepInjectInput) ProposerRewardsDepInjectOutput {
 	rewardAddressProvider := NewProposerRewardsAddressProvider(
 		in.DistributionKeeper,
 		in.StakingKeeper,
 	)
 
-	return DepInjectOutput{RewardsAddressProvider: rewardAddressProvider}
+	return ProposerRewardsDepInjectOutput{RewardsAddressProvider: rewardAddressProvider}
 }

--- a/x/builder/rewards_address_provider/proposer_rewards_address_provider.go
+++ b/x/builder/rewards_address_provider/proposer_rewards_address_provider.go
@@ -1,4 +1,4 @@
-package rewards_address_provider
+package rewardsaddressprovider
 
 import (
 	"cosmossdk.io/depinject"

--- a/x/builder/rewards_address_provider/proposer_rewards_address_provider.go
+++ b/x/builder/rewards_address_provider/proposer_rewards_address_provider.go
@@ -1,6 +1,7 @@
 package rewards_address_provider
 
 import (
+	"cosmossdk.io/depinject"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/skip-mev/pob/x/builder/types"
@@ -27,4 +28,28 @@ func (p *ProposerRewardsAddressProvider) GetRewardsAddress(context sdk.Context) 
 	prevProposer := p.stakingKeeper.ValidatorByConsAddr(context, prevPropConsAddr)
 
 	return sdk.AccAddress(prevProposer.GetOperator())
+}
+
+// Dependency injection
+
+type DepInjectInput struct {
+	depinject.In
+
+	types.DistributionKeeper
+	types.StakingKeeper
+}
+
+type DepInjectOutput struct {
+	depinject.Out
+
+	RewardsAddressProvider RewardsAddressProvider
+}
+
+func Provide(in DepInjectInput) DepInjectOutput {
+	rewardAddressProvider := NewProposerRewardsAddressProvider(
+		in.DistributionKeeper,
+		in.StakingKeeper,
+	)
+
+	return DepInjectOutput{RewardsAddressProvider: rewardAddressProvider}
 }

--- a/x/builder/rewards_address_provider/proposer_rewards_address_provider.go
+++ b/x/builder/rewards_address_provider/proposer_rewards_address_provider.go
@@ -1,0 +1,30 @@
+package rewards_address_provider
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/skip-mev/pob/x/builder/types"
+)
+
+// Provides auction profits to the block proposer.
+type ProposerRewardsAddressProvider struct {
+	distrKeeper   types.DistributionKeeper
+	stakingKeeper types.StakingKeeper
+}
+
+func NewProposerRewardsAddressProvider(
+	distrKeeper types.DistributionKeeper,
+	stakingKeeper types.StakingKeeper,
+) RewardsAddressProvider {
+	return &ProposerRewardsAddressProvider{
+		distrKeeper:   distrKeeper,
+		stakingKeeper: stakingKeeper,
+	}
+}
+
+func (p *ProposerRewardsAddressProvider) GetRewardsAddress(context sdk.Context) sdk.AccAddress {
+	prevPropConsAddr := p.distrKeeper.GetPreviousProposerConsAddr(context)
+	prevProposer := p.stakingKeeper.ValidatorByConsAddr(context, prevPropConsAddr)
+
+	return sdk.AccAddress(prevProposer.GetOperator())
+}

--- a/x/builder/rewards_address_provider/rewards_address_provider.go
+++ b/x/builder/rewards_address_provider/rewards_address_provider.go
@@ -1,4 +1,4 @@
-package rewards_address_provider
+package rewardsaddressprovider
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"

--- a/x/builder/rewards_address_provider/rewards_address_provider.go
+++ b/x/builder/rewards_address_provider/rewards_address_provider.go
@@ -1,0 +1,10 @@
+package rewards_address_provider
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// Provides address for where to send auction profits.
+type RewardsAddressProvider interface {
+	GetRewardsAddress(context sdk.Context) sdk.AccAddress
+}


### PR DESCRIPTION
When integrating into Duality we discovered that not all chains will have a Distribution Module.

To account for this, add a new abstraction, `RewardsAddressProvider` that will instruct the moduled as to where auction rewards should go. There are two options provided:
1. `ProposerRewardsAddressProvider`: Send rewards to the block proposer
2. `FixedAddressRewardsAddressProvider`: Send rewards to the same address

Notes:
- The default dependency injection strategy for the module will use the `Proposer` provider, chains can override this preference
- There is boilerplate code to inject a `Fixed` provider. This will default to the module's address and chains can provide their own injection binding if they want something else. 
- I didn't see a unit test for auction profits, so I haven't added an additional test.  