### PR TITLE
Revert "fix: Allow Custom Address Prefixes"

### DIFF
--- a/abci/abci_test.go
+++ b/abci/abci_test.go
@@ -95,7 +95,7 @@ func (suite *ABCITestSuite) SetupTest() {
 		suite.stakingKeeper,
 		suite.authorityAccount.String(),
 	)
-	err := suite.builderKeeper.SetParams(suite.ctx, buildertypes.DefaultParamsWithAddressPrefix("cosmos"))
+	err := suite.builderKeeper.SetParams(suite.ctx, buildertypes.DefaultParams())
 	suite.Require().NoError(err)
 	suite.builderDecorator = ante.NewBuilderDecorator(suite.builderKeeper, suite.encodingConfig.TxConfig.TxEncoder(), suite.mempool)
 

--- a/x/builder/ante/ante_test.go
+++ b/x/builder/ante/ante_test.go
@@ -68,7 +68,7 @@ func (suite *AnteTestSuite) SetupTest() {
 		suite.stakingKeeper,
 		suite.authorityAccount.String(),
 	)
-	err := suite.builderKeeper.SetParams(suite.ctx, buildertypes.DefaultParamsWithAddressPrefix("cosmos"))
+	err := suite.builderKeeper.SetParams(suite.ctx, buildertypes.DefaultParams())
 	suite.Require().NoError(err)
 }
 

--- a/x/builder/keeper/keeper_test.go
+++ b/x/builder/keeper/keeper_test.go
@@ -61,7 +61,7 @@ func (suite *KeeperTestSuite) SetupTest() {
 		suite.authorityAccount.String(),
 	)
 
-	err := suite.builderKeeper.SetParams(suite.ctx, types.DefaultParamsWithAddressPrefix("cosmos"))
+	err := suite.builderKeeper.SetParams(suite.ctx, types.DefaultParams())
 	suite.Require().NoError(err)
 
 	config := mempool.NewDefaultAuctionFactory(suite.encCfg.TxConfig.TxDecoder())

--- a/x/builder/keeper/msg_server_test.go
+++ b/x/builder/keeper/msg_server_test.go
@@ -44,7 +44,7 @@ func (suite *KeeperTestSuite) TestMsgAuctionBid() {
 				Transactions: [][]byte{{0xFF}, {0xFF}, {0xFF}},
 			},
 			malleate: func() {
-				params := types.DefaultParamsWithAddressPrefix("cosmos")
+				params := types.DefaultParams()
 				params.MaxBundleSize = 2
 				suite.builderKeeper.SetParams(suite.ctx, params)
 			},
@@ -58,7 +58,7 @@ func (suite *KeeperTestSuite) TestMsgAuctionBid() {
 				Transactions: [][]byte{{0xFF}, {0xFF}},
 			},
 			malleate: func() {
-				params := types.DefaultParamsWithAddressPrefix("cosmos")
+				params := types.DefaultParams()
 				params.ProposerFee = sdk.ZeroDec()
 				params.EscrowAccountAddress = escrow.Address.String()
 				suite.builderKeeper.SetParams(suite.ctx, params)
@@ -83,7 +83,7 @@ func (suite *KeeperTestSuite) TestMsgAuctionBid() {
 				Transactions: [][]byte{{0xFF}, {0xFF}},
 			},
 			malleate: func() {
-				params := types.DefaultParamsWithAddressPrefix("cosmos")
+				params := types.DefaultParams()
 				params.ProposerFee = sdk.MustNewDecFromStr("0.30")
 				params.EscrowAccountAddress = escrow.Address.String()
 				suite.builderKeeper.SetParams(suite.ctx, params)

--- a/x/builder/module.go
+++ b/x/builder/module.go
@@ -54,15 +54,8 @@ func (AppModuleBasic) RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 }
 
 // DefaultGenesis returns default genesis state as raw bytes for the builder module.
-//
-// Deprecated: Please use `DefaultGenesisWithAddressPrefix` instead.
 func (AppModuleBasic) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
 	return cdc.MustMarshalJSON(types.DefaultGenesisState())
-}
-
-// DefaultGenesisWithAddressPrefix returns default genesis state as raw bytes for the builder module with a custom address prefix.
-func (AppModuleBasic) DefaultGenesisWithAddressPrefix(cdc codec.JSONCodec, bech32AddressPrefix string) json.RawMessage {
-	return cdc.MustMarshalJSON(types.DefaultGenesisStateWithAddressPrefix(bech32AddressPrefix))
 }
 
 // ValidateGenesis performs genesis state validation for the builder module.

--- a/x/builder/types/genesis.go
+++ b/x/builder/types/genesis.go
@@ -14,18 +14,9 @@ func NewGenesisState(params Params) *GenesisState {
 }
 
 // DefaultGenesisState returns the default GenesisState instance.
-//
-// Deprecated: Please use `DefaultGenesisStateWithAddressPrefix` instead.
 func DefaultGenesisState() *GenesisState {
 	return &GenesisState{
 		Params: DefaultParams(),
-	}
-}
-
-// DefaultGenesisStateWithAddressPrefix returns the default GenesisState instance with a custom address prefix.
-func DefaultGenesisStateWithAddressPrefix(bech32AddressPrefix string) *GenesisState {
-	return &GenesisState{
-		Params: DefaultParamsWithAddressPrefix(bech32AddressPrefix),
 	}
 }
 

--- a/x/builder/types/params.go
+++ b/x/builder/types/params.go
@@ -5,33 +5,26 @@ import (
 
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/address"
-	"github.com/cosmos/cosmos-sdk/types/bech32"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 )
 
 var (
-	DefaultMaxBundleSize             uint32 = 2
-	DefaultEscrowAccountAddressBytes []byte = address.Module(ModuleName)
-	DefaultReserveFee                       = sdk.NewCoin("stake", sdk.NewInt(1))
-	DefaultMinBidIncrement                  = sdk.NewCoin("stake", sdk.NewInt(1))
-	DefaultFrontRunningProtection           = true
-	DefaultProposerFee                      = sdk.ZeroDec()
+	DefaultMaxBundleSize          uint32 = 2
+	DefaultEscrowAccountAddress   string = authtypes.NewModuleAddress(ModuleName).String()
+	DefaultReserveFee                    = sdk.NewCoin("stake", sdk.NewInt(1))
+	DefaultMinBidIncrement               = sdk.NewCoin("stake", sdk.NewInt(1))
+	DefaultFrontRunningProtection        = true
+	DefaultProposerFee                   = sdk.ZeroDec()
 )
 
 // NewParams returns a new Params instance with the provided values.
 func NewParams(
 	maxBundleSize uint32,
-	escrowAccountAddressBytes []byte,
+	escrowAccountAddress string,
 	reserveFee, minBidIncrement sdk.Coin,
 	frontRunningProtection bool,
 	proposerFee sdk.Dec,
-	bech32AddressPrefix string,
 ) Params {
-	escrowAccountAddress, err := bech32.ConvertAndEncode(bech32AddressPrefix, escrowAccountAddressBytes)
-	if err != nil {
-		panic("Could not encode escrow account address")
-	}
-
 	return Params{
 		MaxBundleSize:          maxBundleSize,
 		EscrowAccountAddress:   escrowAccountAddress,
@@ -43,24 +36,14 @@ func NewParams(
 }
 
 // DefaultParams returns the default x/builder parameters.
-//
-// Deprecated: Please use `DefaultParamsWithAddressPrefix` instead.
 func DefaultParams() Params {
-	return DefaultParamsWithAddressPrefix(
-		"cosmos",
-	)
-}
-
-// DefaultParamsWithAddressPrefix returns the default x/builder parameters with a custom address prefix.
-func DefaultParamsWithAddressPrefix(bech32AddressPrefix string) Params {
 	return NewParams(
 		DefaultMaxBundleSize,
-		DefaultEscrowAccountAddressBytes,
+		DefaultEscrowAccountAddress,
 		DefaultReserveFee,
 		DefaultMinBidIncrement,
 		DefaultFrontRunningProtection,
 		DefaultProposerFee,
-		bech32AddressPrefix,
 	)
 }
 


### PR DESCRIPTION
Reverts skip-mev/pob#207

When I wrote 207 I didn't realize these methods were called from the SDK via reflection.